### PR TITLE
Make Transparent Background

### DIFF
--- a/js/eventHandlers.js
+++ b/js/eventHandlers.js
@@ -412,9 +412,9 @@ function Add_EventHandlers_To_Save_Button()
 			imageData.data[pixelIndex] = rgbArray[0];
 			imageData.data[pixelIndex + 1] = rgbArray[1];
 			imageData.data[pixelIndex + 2] = rgbArray[2];
-			imageData.data[pixelIndex + 3] = 255;
+			imageData.data[pixelIndex + 3] = rgbArray[3] !== undefined ? rgbArray[3] : (pixel === "transparent" ? 0 : 255);
 			pixelIndex += 4;
-		})
+		});
 		context.putImageData(imageData, 0, 0);
 
 		let download = document.createElement('a');

--- a/js/script.js
+++ b/js/script.js
@@ -7,7 +7,7 @@ const BUTTON_UP_COLOR = "#a0a0a0";
 const BUTTON_UP_OUTLINE = "";
 const BUTTON_DOWN_COLOR = "#f0f0f0";
 const BUTTON_DOWN_OUTLINE = "1px solid blue";
-const CANVAS_INIT_COLOR = palette_color_array[0];
+const CANVAS_INIT_COLOR = "transparent";  // Or "rgba(0,0,0,0)"
 let ACTIVE_COLOR_SELECT = "firstColor";
 const STATE = {
     "firstColor": palette_color_array[palette_color_array.length - 1],

--- a/js/script.js
+++ b/js/script.js
@@ -7,7 +7,7 @@ const BUTTON_UP_COLOR = "#a0a0a0";
 const BUTTON_UP_OUTLINE = "";
 const BUTTON_DOWN_COLOR = "#f0f0f0";
 const BUTTON_DOWN_OUTLINE = "1px solid blue";
-const CANVAS_INIT_COLOR = "transparent";  // Or "rgba(0,0,0,0)"
+const CANVAS_INIT_COLOR = "transparent";
 let ACTIVE_COLOR_SELECT = "firstColor";
 const STATE = {
     "firstColor": palette_color_array[palette_color_array.length - 1],

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,5 +1,8 @@
 function Get_Array_From_Rgb(rgb)
 {
+    if (rgb === "transparent") {
+        return [0, 0, 0, 0];
+    }
     rgb = rgb.replace(" ", "");
     rgb = rgb.slice(4,rgb.length-1);
 

--- a/main.css
+++ b/main.css
@@ -22,6 +22,10 @@
   --toolbar-background-color: #777;
 
   --shadow: 2px 2px 8px #224;
+
+  --checkerboard_color_light: #FFFFFF;
+  --checkerboard_color_dark: #CBCBCB;
+  --checkerboard_square_width: 8px;
 }
 
 .no-select {
@@ -301,12 +305,12 @@ body {
 	height: var(--canvas-width);
 	margin-right: var(--palette-margin-right);
 	float: left;
-	background: 
-		linear-gradient(45deg, #c0c0c0 25%, transparent 25%, transparent 75%, #c0c0c0 75%, #c0c0c0),
-		linear-gradient(45deg, #c0c0c0 25%, transparent 25%, transparent 75%, #c0c0c0 75%, #c0c0c0);
-	background-position: 0 0, 64px 64px;
-	background-size: 128px 128px;
-	background-color: #808080;
+	background:
+		linear-gradient(45deg, var(--checkerboard_color_light) 25%, transparent 25%, transparent 75%, var(--checkerboard_color_light) 75%, var(--checkerboard_color_light)),
+		linear-gradient(45deg, var(--checkerboard_color_light) 25%, transparent 25%, transparent 75%, var(--checkerboard_color_light) 75%, var(--checkerboard_color_light));
+	background-position: 0 0, var(--checkerboard_square_width) var(--checkerboard_square_width);
+	background-size: calc(2 * var(--checkerboard_square_width)) calc(2 * var(--checkerboard_square_width));
+	background-color: var(--checkerboard_color_dark);
 }
 
 #palette-div {

--- a/main.css
+++ b/main.css
@@ -26,11 +26,11 @@
 
 .no-select {
   -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-     -khtml-user-select: none; /* Konqueror HTML */
-       -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Chrome, Opera and Firefox */
+	-webkit-user-select: none; /* Safari */
+	 -khtml-user-select: none; /* Konqueror HTML */
+	   -moz-user-select: none; /* Old versions of Firefox */
+		-ms-user-select: none; /* Internet Explorer/Edge */
+			user-select: none; /* Chrome, Opera and Firefox */
 }
 
 body {
@@ -292,7 +292,7 @@ body {
 	left: calc(var(--toolbar-width) + var(--palette-width) - var(--color-preview-width));
 }
 .active_indicator {
-  border: 2px solid #eef !important;
+	border: 2px solid #eef !important;
 }
 
 #canvas-div {
@@ -301,6 +301,12 @@ body {
 	height: var(--canvas-width);
 	margin-right: var(--palette-margin-right);
 	float: left;
+	background: 
+		linear-gradient(45deg, #c0c0c0 25%, transparent 25%, transparent 75%, #c0c0c0 75%, #c0c0c0),
+		linear-gradient(45deg, #c0c0c0 25%, transparent 25%, transparent 75%, #c0c0c0 75%, #c0c0c0);
+	background-position: 0 0, 64px 64px;
+	background-size: 128px 128px;
+	background-color: #808080;
 }
 
 #palette-div {


### PR DESCRIPTION
**What is it?**

- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

**Description of the changes in your PR**

- Changed `main.css` to make the grid background for the canvas transparent
- Changed `script.js` and `eventHandlers.js` so that the background can be transparent on the canvas and when save images to PNG

**Before/After Screenshots/Screen Record**
- Before:
![Screenshot from 2024-05-24 21-59-52](https://github.com/Kully/pixel-paint/assets/77735678/5ed3d0ad-4218-4aef-b141-87125bf38c65)

- After:
![Screenshot from 2024-05-24 20-47-09](https://github.com/Kully/pixel-paint/assets/77735678/a697a137-acc6-4c2a-8f29-504a31b1b375)

**Fixes the following issue(s)**
- Fixes #24 

**Reasons for doing this PR**

I like drawings with transparent backgrounds so it's easier to use them without having to use external conversion tools to change the background color from white to transparent with icon images or something else.
Beside, if you still want the white background as before you can still use white `fill` on the canvas before starting your painting.