### PR TITLE
shortcut to clear out the canvas

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -796,6 +796,9 @@ function Add_EventHandlers_To_Document()
         {
             Delete_Selected();
         }
+        if(e.code === "KeyK"){
+            Clear_Paint_From_Canvas()
+        }
         if(e.code === "Escape")
         {
             Remove_Selection();

--- a/js/utils.js
+++ b/js/utils.js
@@ -163,3 +163,11 @@ function Get_Canvas_Pixels()
     })
     return canvasPixels;
 }
+
+function Clear_Paint_From_Canvas()
+{
+    let canvasCells = document.querySelectorAll(".canvasCell");
+    canvasCells.forEach(function(cell){
+        cell.style.backgroundColor = CANVAS_INIT_COLOR;
+    })
+}


### PR DESCRIPTION
This was an idea I had for clearing the canvas. The functionality is pretty simple. Press 'k' to clear out the canvas.

Still need input:
- Would a different key be better?
- Should this be added to the top bar?