### PR TITLE
Add drop shadow preview for active tool (#33)

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
 			</div>
 
 			<div id="canvas-div"></div>
+			<div id="drop-shadow-preview"></div>
 			<div id="palette-select">
 				<label class="container">
 					<span class="checkmark"></span>

--- a/js/script.js
+++ b/js/script.js
@@ -345,7 +345,7 @@ function Show_Drop_Shadow(e) {
         dropShadowPreview.style.display = "none"; 
     }
     dropShadowPreview.style.left = `${cellX}px`;
-    dropShadowPreview.style.top = `${cellY + 2.3 * CELL_WIDTH_PX}px`;
+    dropShadowPreview.style.top = `${cellY + 2.38 * CELL_WIDTH_PX}px`;
 }
 
 Color_All_Toolbar_Buttons();

--- a/js/script.js
+++ b/js/script.js
@@ -348,6 +348,10 @@ function Show_Drop_Shadow(e) {
     dropShadowPreview.style.top = `${cellY + 2.38 * CELL_WIDTH_PX}px`;
 }
 
+function Hide_Drop_Shadow() {
+    dropShadowPreview.style.display = "none";
+}
+
 Color_All_Toolbar_Buttons();
 Update_Active_Color_Preview();
 Populate_Canvas_With_Cells();
@@ -359,3 +363,4 @@ Activate_Tool("pencil");
 Select_Palette();
 Add_EventHandlers();
 canvasDiv.addEventListener("mousemove", Show_Drop_Shadow);
+canvasDiv.addEventListener("mouseleave", Hide_Drop_Shadow);

--- a/js/script.js
+++ b/js/script.js
@@ -45,6 +45,9 @@ const PALETTE_DISPLAY = {
 const HISTORY_STATES = new History_States(MAX_UNDOS);
 Save_Canvas_State();
 
+const dropShadowPreview = document.getElementById("drop-shadow-preview");
+const canvasDiv = document.getElementById("canvas-div");
+
 function Canvas_Cursor_XY(e)
 {
     let parentCell = e.target.closest("div.canvasCell");
@@ -316,6 +319,35 @@ function Select_Palette() {
     }
 }
 
+function Show_Drop_Shadow(e) {
+    const rect = canvasDiv.getBoundingClientRect();
+    const paddingLeft = parseFloat(window.getComputedStyle(canvasDiv).paddingLeft); 
+    const paddingTop = parseFloat(window.getComputedStyle(canvasDiv).paddingTop); 
+
+    const mouseX = e.clientX - rect.left - paddingLeft; 
+    const mouseY = e.clientY - rect.top - paddingTop;
+
+    const cellX = Math.floor(mouseX / CELL_WIDTH_PX) * CELL_WIDTH_PX;
+    const cellY = Math.floor(mouseY / CELL_WIDTH_PX) * CELL_WIDTH_PX;
+
+    dropShadowPreview.style.display = "block";
+
+    if (STATE["activeTool"] === "pencil" || STATE["activeTool"] === "fill") {
+        if (STATE[ACTIVE_COLOR_SELECT].startsWith("#aN")) {
+            dropShadowPreview.style.display = "none";
+        } else {
+            dropShadowPreview.style.backgroundColor = STATE[ACTIVE_COLOR_SELECT];
+        }
+    }
+    else if (STATE["activeTool"] === "eraser") {
+        dropShadowPreview.style.backgroundColor = "rgba(255, 255, 255, 0.5)";
+    } else {
+        dropShadowPreview.style.display = "none"; 
+    }
+    dropShadowPreview.style.left = `${cellX}px`;
+    dropShadowPreview.style.top = `${cellY + 2.3 * CELL_WIDTH_PX}px`;
+}
+
 Color_All_Toolbar_Buttons();
 Update_Active_Color_Preview();
 Populate_Canvas_With_Cells();
@@ -326,3 +358,4 @@ Update_Tooltip_Text();
 Activate_Tool("pencil");
 Select_Palette();
 Add_EventHandlers();
+canvasDiv.addEventListener("mousemove", Show_Drop_Shadow);

--- a/main.css
+++ b/main.css
@@ -412,3 +412,12 @@ input[type="radio"] {
 	transition: opacity .2s ease;
 }
   
+#drop-shadow-preview {
+    position: absolute;
+    pointer-events: none;
+    border: 1px solid rgba(0, 0, 0, 0.5); 
+    display: none;
+    width: var(--canvas-cell-width); 
+    height: var(--canvas-cell-width);
+    opacity: 0.5; 
+}

--- a/main.css
+++ b/main.css
@@ -415,7 +415,6 @@ input[type="radio"] {
 #drop-shadow-preview {
     position: absolute;
     pointer-events: none;
-    border: 1px solid rgba(0, 0, 0, 0.5); 
     display: none;
     width: var(--canvas-cell-width); 
     height: var(--canvas-cell-width);


### PR DESCRIPTION
Issue #33: Show drop shadow. 
🔹 What does this PR do?
Add drop shadow preview effect when selecting pencil and eraser tools.
When selecting pencil tool, shadow will be the color has chosen with the opaque 50%.
When selecting eraser, shadow will be opaque white (rgba(255, 255, 255, 0.5)).
If the selected color is #aN, shadow will not be displayed.
🔹 Why is this needed?
Allows users to preview the drawing position before clicking.
Improves the experience when using the tool.